### PR TITLE
Bring rust benchmarks in line with c benchmarks

### DIFF
--- a/benchmarks/rust_hashmap.rs
+++ b/benchmarks/rust_hashmap.rs
@@ -1,20 +1,66 @@
-use std::time::{Instant};
-use std::io::Read;
+use std::{
+    hash::{BuildHasherDefault, Hasher},
+    io::Read,
+    time::Instant,
+};
 
-fn romu_rotl(val: u64, r: u32) -> u64
-    { return (val << r) | (val >> (64 - r)); }
+struct MyHasher {
+    seed: u64,
+}
 
-fn romu_trio(s: &mut[u64]) -> u64 {
-    let xp = s[0]; let yp = s[1]; let zp = s[2];
-    s[0] = 15241094284759029579 * zp;
-    s[1] = yp - xp; s[1] = romu_rotl(s[1], 12);
-    s[2] = zp - yp; s[2] = romu_rotl(s[2], 44);
+impl Default for MyHasher {
+    fn default() -> Self {
+        Self { seed: 0xb5ad4eceda1ce2a9_u64 }
+    }
+}
+
+// fn rotl(h: u64, y: u64) -> u64 {
+//     (h << y) | (h >> (64 - y))
+// }
+
+impl Hasher for MyHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        use std::convert::TryInto;
+        self.seed = u64::from_ne_bytes(bytes.try_into().unwrap()).wrapping_mul(0xc6a4a7935bd1e99d);
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.seed = i.wrapping_mul(0xc6a4a7935bd1e99d);
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.seed
+    }
+}
+
+type MyBuildHasher = BuildHasherDefault<MyHasher>;
+
+#[inline]
+fn romu_rotl(val: u64, r: u32) -> u64 {
+    return (val.wrapping_shl(r)).wrapping_add(val.wrapping_shr(64_u32.wrapping_sub(r)));
+}
+
+fn romu_trio(s: &mut [u64]) -> u64 {
+    let xp = s[0];
+    let yp = s[1];
+    let zp = s[2];
+    s[0] = 15241094284759029579_u64.wrapping_mul(zp);
+    s[1] = yp.wrapping_sub(xp);
+    s[1] = romu_rotl(s[1], 12);
+    s[2] = zp.wrapping_sub(yp);
+    s[2] = romu_rotl(s[2], 44);
     return xp;
 }
 
 fn main() {
-    let n = 50_000_000; let mask = (1 << 25) - 1;
-    let mut m = std::collections::HashMap::<u64, u64>::with_capacity(n);
+    let n = 50_000_000;
+    let mask = (1 << 25) - 1;
+
+    let mut m = std::collections::HashMap::<u64, u64, MyBuildHasher>::default();
+    m.reserve(n);
+
     let mut rng: [u64; 3] = [1872361123, 123879177, 87739234];
     println!("Rust HashMap  n = {}, mask = {:#x}", n, mask);
     let now = Instant::now();
@@ -40,5 +86,6 @@ fn main() {
         m.remove(&key);
     }
     println!("remove  : {}ms  \tsize : {}", now.elapsed().as_millis(), m.len());
-    println!("press a key:"); std::io::stdin().bytes().next();
+    println!("press a key:");
+    std::io::stdin().bytes().next();
 }


### PR DESCRIPTION
I'm not super familiar with C macros so I'm not sure if I used the correct hash (I think it was just the `c_default_hash64` macro thing). The `Hasher` is able to specialize and only calls `MyHasher::write_u64` so the general `MyHasher::write` method isn't called. I also changed a few adds to `wrapping_adds` mostly because it goes from 3ish instructions to 1 and there were a few panics multiplying in `rumo_trio`.

rust is still slower
```
gcc -I./include -O3 ./benchmarks/rust_cmap.c
./rust_cmap
STC cmap  n = 50000000, mask = 0x1ffffff
insert  : 1756ms        size : 25994494
lookup  : 574ms         sum  : 25994494
iterate : 124ms         sum  : 50000000
remove  : 1558ms        size : 0
press a key:

rustc -O --edition=2018 --crate-type=bin ./benchmarks/rust_hashmap.rs
./rust_hashmap
Rust HashMap  n = 50000000, mask = 0x1ffffff
insert  : 3588ms        size : 25994494
lookup  : 1316ms        sum  : 25994494
iterate : 75ms          sum  : 50000000
remove  : 3413ms        size : 0
press a key:
```