### PR TITLE
add emhash to benchmark

### DIFF
--- a/benchmarks/shootout_hashmaps.cpp
+++ b/benchmarks/shootout_hashmaps.cpp
@@ -17,6 +17,7 @@
 //#include "external/parallel_hashmap/phmap.h"
 //#include "external/tsl/hopscotch_map.h"
 #include "external/tsl/robin_map.h"
+#include "external/emhash/hash_table7.hpp"
 
 template<typename C> inline void std_destroy(C& c) { C().swap(c); }
 
@@ -134,6 +135,18 @@ KHASH_MAP_INIT_INT64(ii, int64_t)
 #define DMAP_CLEAR(X)             UMAP_CLEAR(X)
 #define DMAP_DTOR(X)              UMAP_DTOR(X)
 
+#define EMAP_SETUP(X, Key, Value) emhash7::HashMap<Key, Value> map; map.max_load_factor(MAX_LOAD_FACTOR/100.0f)
+#define EMAP_PUT(X, key, val)     UMAP_PUT(X, key, val)
+#define EMAP_EMPLACE(X, key, val) UMAP_EMPLACE(X, key, val)
+#define EMAP_FIND(X, key)         UMAP_FIND(X, key)
+#define EMAP_ERASE(X, key)        UMAP_ERASE(X, key)
+#define EMAP_FOR(X, i)            UMAP_FOR(X, i)
+#define EMAP_ITEM(X, i)           UMAP_ITEM(X, i)
+#define EMAP_SIZE(X)              UMAP_SIZE(X)
+#define EMAP_BUCKETS(X)           UMAP_BUCKETS(X)
+#define EMAP_CLEAR(X)             UMAP_CLEAR(X)
+#define EMAP_DTOR(X)              UMAP_DTOR(X)
+
 #define PMAP_SETUP(X, Key, Value) phmap::flat_hash_map<Key, Value> map; map.max_load_factor(MAX_LOAD_FACTOR/100.0f)
 #define PMAP_PUT(X, key, val)     UMAP_PUT(X, key, val)
 #define PMAP_EMPLACE(X, key, val) UMAP_EMPLACE(X, key, val)
@@ -240,7 +253,7 @@ KHASH_MAP_INIT_INT64(ii, int64_t)
 #define RUN_TEST(n) MAP_TEST##n(KMAP, ii, N##n) MAP_TEST##n(CMAP, ii, N##n) \
                     MAP_TEST##n(FMAP, ii, N##n) MAP_TEST##n(TMAP, ii, N##n) \
                     MAP_TEST##n(RMAP, ii, N##n) MAP_TEST##n(DMAP, ii, N##n) \
-                    MAP_TEST##n(UMAP, ii, N##n)
+                    MAP_TEST##n(EMAP, ii, N##n) MAP_TEST##n(UMAP, ii, N##n)
 #else
 #define RUN_TEST(n) MAP_TEST##n(KMAP, ii, N##n) MAP_TEST##n(CMAP, ii, N##n)
 #endif
@@ -268,6 +281,7 @@ int main(int argc, char* argv[])
            //"HMAP = https://github.com/Tessil/hopscotch-map\n"
            "RMAP = https://github.com/martinus/robin-hood-hashing\n"
            "DMAP = https://github.com/martinus/unordered_dense\n"
+           "EMAP = https://github.com//ktprime/emhash\n"
            "UMAP = std::unordered_map\n\n");
            
     printf("Usage %s [n-million=%d key-bits=%d]\n", argv[0], DEFAULT_N_MILL, DEFAULT_KEYBITS);


### PR DESCRIPTION
please add emhash test

C:\WINDOWS\system32\cmd.exe /c (g++ -I. -I.. -I../../include -std=c++17 -O3 -march=native -pipe \emhash\STC\benchmarks\shootout_hashmaps.cpp -o \emhash\STC\benchmarks\shootout_hashmaps.exe ^& \emhash\STC\benchmarks\shootout_hashmaps)

Unordered hash map shootout
KMAP = https://github.com/attractivechaos/klib
CMAP = https://github.com/tylov/STC (**)
FMAP = https://github.com/skarupke/flat_hash_map
TMAP = https://github.com/Tessil/robin-map
RMAP = https://github.com/martinus/robin-hood-hashing
DMAP = https://github.com/martinus/unordered_dense
EMAP = https://github.com//ktprime/emhash
UMAP = std::unordered_map

Usage \emhash\STC\benchmarks\shootout_hashmaps [n-million=10 key-bits=22]
N-base = 10. Random keys are in range [0, 2^22). Seed = 1657156583:

T1: Insert/update random keys:
KMAP: time: 0.234, size: 2920684, buckets:  4194304, sum: 8720457106852
CMAP: time: 0.212, size: 2920684, buckets:  4374477, sum: 8720457106852
FMAP: time: 0.250, size: 2920684, buckets:  4194304, sum: 8720457106852
TMAP: time: 0.203, size: 2920684, buckets:  4194304, sum: 8720457106852
RMAP: time: 0.220, size: 2920684, buckets:  4194303, sum: 8720457106852
DMAP: time: 0.400, size: 2920684, buckets:  4194304, sum: 8720457106852
EMAP: time: 0.203, size: 2920684, buckets:  4194304, sum: 8720457106852
UMAP: time: 1.353, size: 2920684, buckets:  7556579, sum: 8720457106852

T2: Insert sequential keys, then remove them in same order:
KMAP: time: 0.228, size: 0, buckets:  8388608, erased 5000000
CMAP: time: 0.313, size: 0, buckets:  6561721, erased 5000000
FMAP: time: 0.360, size: 0, buckets:  8388608, erased 5000000
TMAP: time: 0.148, size: 0, buckets:  8388608, erased 5000000
RMAP: time: 0.437, size: 0, buckets:  8388607, erased 5000000
DMAP: time: 0.791, size: 0, buckets:  8388608, erased 5000000
EMAP: time: 0.093, size: 0, buckets:  8388608, erased 5000000
UMAP: time: 0.532, size: 0, buckets:  7556579, erased 5000000

T3: Remove random keys:
KMAP: time: 0.187, size: 0, buckets:  8388608, erased 3807971
CMAP: time: 0.211, size: 0, buckets:  6561721, erased 3807971
FMAP: time: 0.188, size: 0, buckets:  8388608, erased 3807971
TMAP: time: 0.187, size: 0, buckets:  8388608, erased 3807971
RMAP: time: 0.242, size: 0, buckets:  8388607, erased 3807971
DMAP: time: 0.392, size: 0, buckets:  8388608, erased 3807971
EMAP: time: 0.312, size: 0, buckets:  8388608, erased 3807971
UMAP: time: 0.696, size: 0, buckets:  7556579, erased 3807971

T4: Iterate random keys:
KMAP: time: 0.360, size: 3626726, buckets:  8388608, repeats: 27, sum: 539277796556937
CMAP: time: 0.328, size: 3626726, buckets:  6561721, repeats: 27, sum: 539277796556937
FMAP: time: 0.626, size: 3626726, buckets:  8388608, repeats: 27, sum: 539277796556937
TMAP: time: 0.361, size: 3626726, buckets:  8388608, repeats: 27, sum: 539277796556937
RMAP: time: 0.320, size: 3626726, buckets:  8388607, repeats: 27, sum: 539277796556937
DMAP: time: 0.079, size: 3626726, buckets:  8388608, repeats: 27, sum: 539277796556937
EMAP: time: 0.158, size: 3626726, buckets:  8388608, repeats: 27, sum: 539277796556937
UMAP: time: 2.215, size: 3626726, buckets:  7556579, repeats: 27, sum: 539277796556937

T5: Lookup random keys:
KMAP: time: 0.696, size: 3626726, buckets:  8388608, lookups: 37007958, found: 33136289
CMAP: time: 0.758, size: 3626726, buckets:  6561721, lookups: 37007958, found: 33136289
FMAP: time: 0.626, size: 3626726, buckets:  8388608, lookups: 37007958, found: 33136289
TMAP: time: 0.603, size: 3626726, buckets:  8388608, lookups: 37007958, found: 33136289
RMAP: time: 1.197, size: 3626726, buckets:  8388607, lookups: 37007958, found: 33136289
DMAP: time: 1.212, size: 3626726, buckets:  8388608, lookups: 37007958, found: 33136289
EMAP: time: 0.563, size: 3626726, buckets:  8388608, lookups: 37007958, found: 33136289
UMAP: time: 2.750, size: 3626726, buckets:  7556579, lookups: 37007958, found: 33136289