### PR TITLE
refactor c_forlist, avoid expanding __VA_ARGS__ 3 times

### DIFF
--- a/include/stc/ccommon.h
+++ b/include/stc/ccommon.h
@@ -223,10 +223,8 @@ STC_INLINE char* c_strnstrn(const char *s, const char *needle,
          ; (i.val > i._end) ^ (i._inc > 0); i.val += i._inc)
 
 #define c_forlist(it, T, ...) \
-    for (struct {T* data; T* ref; size_t index;} \
-         it = {.data=(T[])__VA_ARGS__, .ref=it.data} \
-         ; it.ref != &it.data[c_arraylen(((T[])__VA_ARGS__))] \
-         ; ++it.ref, ++it.index)
+    for (T _i_data[]=__VA_ARGS__, *_i_data_end=_i_data+c_arraylen(_i_data); _i_data_end; _i_data_end=NULL) \
+    for (struct {T* ref; size_t index;} it = {.ref=_i_data}; it.ref < _i_data_end; ++it.ref, ++it.index)
 
 // [deprecated] - replaced by c_forlist():
 #define c_forarray(T, v, ...) \


### PR DESCRIPTION
(the outer-for loops only once)