### PR TITLE
Fix typo in forward declaration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ typedef struct Dataset {
 
 ...
 // Implementation
-#define c_opt c_is_forward                  // flag that the container was forward declared.
+#define i_opt c_is_forward                  // flag that the container was forward declared.
 #define i_val struct Point
 #define i_tag pnt
 #include <stc/cstack.h>


### PR DESCRIPTION
I couldn't get forward declarations to work because I copied the typo from the README.